### PR TITLE
Allow null for user_id in Invitee.cs

### DIFF
--- a/src/RobinApi.Net/Model/Invitee.cs
+++ b/src/RobinApi.Net/Model/Invitee.cs
@@ -13,7 +13,7 @@ namespace RobinApi.Net.Model
         public string EventId { get; set; }
 
         [DataMember(Name = "user_id", EmitDefaultValue = false)]
-        public int UserId { get; set; }
+        public int? UserId { get; set; }
 
         [DataMember(Name = "email", EmitDefaultValue = false)]
         public string Email { get; set; }


### PR DESCRIPTION
The Robin API returns a null user_id for invitees of an event in some cases. This causes a serialization error. This change makes the UserId nullable.